### PR TITLE
Error message improvement

### DIFF
--- a/cmd/gomodtrace/main.go
+++ b/cmd/gomodtrace/main.go
@@ -11,16 +11,18 @@ import (
 	"github.com/godepsresolve/gomodtrace"
 )
 
+const minimalRatio = 0.9
+
 func tracePaths(parent, target string) {
 	input := readInput()
 	graph := gomodtrace.ParseGraph(input)
 	index := gomodtrace.BuildGraphIndex(graph)
 	if _, ok := index[parent]; !ok {
-		fmt.Printf("No parent package: '%s' found in package index, check input\n", parent)
+		fmt.Println(prepareExtendedMessage(index, minimalRatio, parent, "parent"))
 		return
 	}
 	if _, ok := index[target]; !ok {
-		fmt.Printf("No target package: '%s' found in package index, check input\n", target)
+		fmt.Println(prepareExtendedMessage(index, minimalRatio, target, "target"))
 		return
 	}
 
@@ -28,6 +30,51 @@ func tracePaths(parent, target string) {
 	log.Printf("%v\n", paths)
 	involvedLibraries := paths.ListInvolvedLibraries()
 	fmt.Println(graph.WithOnly(involvedLibraries))
+}
+
+// stringMatchRatio calculates match ratio between two strings.
+func stringMatchRatio(a, b string) float64 {
+	if a == b {
+		return 1.0
+	}
+
+	minLenSequence := min(len(a), len(b))
+	if minLenSequence == 0 {
+		return 0
+	}
+
+	found := float64(0)
+	for i := 0; i < minLenSequence; i++ {
+		if a[i] == b[i] {
+			found++
+		}
+	}
+
+	return found / float64(minLenSequence)
+}
+
+// prepareExtendedMessage prepares an extended message based on the
+// string matching ratio.
+func prepareExtendedMessage(
+	index gomodtrace.NodeIndex,
+	minRatio float64,
+	element,
+	elementType string,
+) string {
+	message := "check input"
+	for k := range index {
+		if stringMatchRatio(k, element) > minRatio {
+			message = fmt.Sprintf("did you mean '%s'?", k)
+			break
+		}
+	}
+
+	return fmt.Sprintf(
+		"No %s package: '%s' found in package index, %s",
+		elementType,
+		element,
+		message,
+	)
 }
 
 func readInput() []string {

--- a/cmd/gomodtrace/main.go
+++ b/cmd/gomodtrace/main.go
@@ -16,15 +16,11 @@ func tracePaths(parent, target string) {
 	graph := gomodtrace.ParseGraph(input)
 	index := gomodtrace.BuildGraphIndex(graph)
 	if _, ok := index[parent]; !ok {
-		fmt.Println(
-			fmt.Sprintf("No parent package: '%s' found in package index, check input", parent),
-		)
+		fmt.Printf("No parent package: '%s' found in package index, check input\n", parent)
 		return
 	}
 	if _, ok := index[target]; !ok {
-		fmt.Println(
-			fmt.Sprintf("No target package: '%s' found in package index, check input", target),
-		)
+		fmt.Printf("No target package: '%s' found in package index, check input\n", target)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/godepsresolve/gomodtrace
 
-go 1.20
+go 1.22


### PR DESCRIPTION
The error returned if the parent or target package is not found is not very informative. Enrich the error with information about the package you are looking for.